### PR TITLE
Minor cleanup to make calendar WAI level A compliant

### DIFF
--- a/zabuto_calendar.js
+++ b/zabuto_calendar.js
@@ -57,7 +57,7 @@ $.fn.zabuto_calendar = function (options) {
 
             $legendObj = drawLegend($calendarElement);
 
-            var $containerHtml = $('<div class="zabuto_calendar" id="' + $calendarElement.attr('id') + '"></div>');
+            var $containerHtml = $('<div class="zabuto_calendar"></div>');
             $containerHtml.append($tableObj);
             $containerHtml.append($legendObj);
 
@@ -206,8 +206,8 @@ $.fn.zabuto_calendar = function (options) {
 
             var monthLabels = $calendarElement.data('monthLabels');
 
-            var $prevMonthCell = $('<th></th>').append($prevMonthNav);
-            var $nextMonthCell = $('<th></th>').append($nextMonthNav);
+            var $prevMonthCell = $('<td></td>').append($prevMonthNav);
+            var $nextMonthCell = $('<td></td>').append($nextMonthNav);
 
             var $currMonthLabel = $('<span>' + monthLabels[month] + ' ' + year + '</span>');
             $currMonthLabel.dblclick(function () {
@@ -215,7 +215,7 @@ $.fn.zabuto_calendar = function (options) {
                 drawTable($calendarElement, $tableObj, dateInitObj.getFullYear(), dateInitObj.getMonth());
             });
 
-            var $currMonthCell = $('<th colspan="5"></th>');
+            var $currMonthCell = $('<td colspan="5"></td>');
             $currMonthCell.append($currMonthLabel);
 
             var $monthHeaderRow = $('<tr class="calendar-month-header"></tr>');
@@ -604,7 +604,7 @@ $.fn.zabuto_calendar_language = function (lang) {
                 dow_labels: ["أثنين", "ثلاثاء", "اربعاء", "خميس", "جمعه", "سبت", "أحد"]
             };
             break;
-            
+
         case 'es':
             return {
                 month_labels: ["Enero", "Febrero", "Marzo", "Abril", "Mayo", "Junio", "Julio", "Agosto", "Septiembre", "Octubre", "Noviembre", "Diciembre"],


### PR DESCRIPTION
Replaced th with td (month and prev/forward buttons shouldn't be
in a th tag. Removed duplicate id which is unnecessary.
http://squizlabs.github.io/HTML_CodeSniffer/ shows no errors on
WCAG2.0 level A anymore.